### PR TITLE
Update selection option

### DIFF
--- a/doc_source/getting-started-lambda-non-proxy-integration.md
+++ b/doc_source/getting-started-lambda-non-proxy-integration.md
@@ -90,7 +90,7 @@ Now, create the `GetStartedLambdaIntegration` Lambda function\.
 
    1. For **Runtime**, choose a supported Node\.js runtime\.
 
-   1. For **Role**, choose `Create new role from template(s)`\.
+   1. For **Role**, choose `Create a new role from AWS policy templates`\.
 
    1. For **Role name**, type a name for your role \(for example, **GetStartedLambdaIntegrationRole**\)\.
 


### PR DESCRIPTION
The original selection option "Create new role from template(s)." is obsoleted. The new role shall be "Create a new role from AWS policy templates".

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
